### PR TITLE
Fix YED error by adding meta.platforms to Darwin JRE

### DIFF
--- a/pkgs/development/compilers/openjdk-darwin/default.nix
+++ b/pkgs/development/compilers/openjdk-darwin/default.nix
@@ -33,5 +33,9 @@ let
 
     passthru.jre = jdk;
 
+    meta = {
+      platforms = stdenv.lib.platforms.linux;
+    };
+
   };
 in jdk


### PR DESCRIPTION
Without this packages which refer to jre.meta.platforms will fail due to a missing attribute error. In particular, this occurs with the YED package.