### PR TITLE
Allow building sandboxed nix

### DIFF
--- a/pkgs/development/libraries/serf/default.nix
+++ b/pkgs/development/libraries/serf/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
     ${gnused}/bin/sed -e '/^env[.]Append(BUILDERS/ienv.Append(ENV={"PATH":os.environ["PATH"]})' -i SConstruct
     ${gnused}/bin/sed -e '/^env[.]Append(BUILDERS/ienv.Append(ENV={"NIX_CFLAGS_COMPILE":os.environ["NIX_CFLAGS_COMPILE"]})' -i SConstruct
     ${gnused}/bin/sed -e '/^env[.]Append(BUILDERS/ienv.Append(ENV={"NIX_LDFLAGS":os.environ["NIX_LDFLAGS"]})' -i SConstruct
-    ${gnused}/bin/sed -e '/^env[.]Append(BUILDERS/ienv.Append(ENV={"NIX_LDFLAGS_BEFORE":os.environ["NIX_LDFLAGS_BEFORE"]})' -i SConstruct
     ${gnused}/bin/sed -e '/^env[.]Append(BUILDERS/ienv.Append(ENV={"TMPDIR":os.environ["TMPDIR"]})' -i SConstruct
   '';
 


### PR DESCRIPTION
7ccaeef1c379e2856041a59c6ee0e67b896e3046 added this, but I now get a crash in Python in the `os.environ` call. This may not be the correct fix, but it allows the `nix-env -f release.nix -iA build.x86_64-darwin` build to complete.