### PR TITLE
Add libiconv arguments to ghc expressions

### DIFF
--- a/pkgs/development/compilers/ghc/6.10.2-binary.nix
+++ b/pkgs/development/compilers/ghc/6.10.2-binary.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, perl, libedit, ncurses, gmp}:
+{stdenv, fetchurl, perl, libedit, ncurses, gmp, libiconv}:
 
 stdenv.mkDerivation rec {
   version = "6.10.2";

--- a/pkgs/development/compilers/ghc/6.10.4.nix
+++ b/pkgs/development/compilers/ghc/6.10.4.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, libedit, ghc, perl, gmp, ncurses}:
+{stdenv, fetchurl, libedit, ghc, perl, gmp, ncurses, libiconv}:
 
 stdenv.mkDerivation rec {
   version = "6.10.4";

--- a/pkgs/development/compilers/ghc/6.12.3.nix
+++ b/pkgs/development/compilers/ghc/6.12.3.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ghc, perl, gmp, ncurses}:
+{stdenv, fetchurl, ghc, perl, gmp, ncurses, libiconv}:
 
 stdenv.mkDerivation rec {
   version = "6.12.3";


### PR DESCRIPTION
f864615c0f2a0c0ec62340d2109e3e18d69d444c added libiconv to all the ghc versions in haskell-ng.