### PR TITLE
fftw: disable-openmp for x86_64-darwin because clang-3.5 doesn't support openmp

### DIFF
--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
     ]
     ++ optional (precision != "double") "--enable-${precision}"
     # all x86_64 have sse2
-    ++ optional stdenv.isx86_64 "--enable-sse2";
+    ++ optional stdenv.isx86_64 "--enable-sse2"
+    ++ optional (stdenv.system == "x86_64-darwin") "--disable-openmp";
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ++ optional (precision != "double") "--enable-${precision}"
     # all x86_64 have sse2
     ++ optional stdenv.isx86_64 "--enable-sse2"
-    ++ optional (stdenv.system == "x86_64-darwin") "--disable-openmp";
+    ++ optional stdenv.isDarwin "--disable-openmp";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
currently I had the following error. 
```
.configure: error: don't know how to enable OpenMP
builder for ‘/nix/store/mk375dkk7g4j687icwanxsvr3lm6zl5w-fftw-double-3.3.4.drv’ failed with exit code 1
error: build of ‘/nix/store/mk375dkk7g4j687icwanxsvr3lm6zl5w-fftw-double-3.3.4.drv’ failed
```

so I turn on `--disable-openmp` if it is darwin.