### PR TITLE
sw_vers: Use binutils

### DIFF
--- a/pkgs/os-specific/darwin/sw_vers/default.nix
+++ b/pkgs/os-specific/darwin/sw_vers/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, binutils_raw }:
+{ stdenv, binutils }:
 
 stdenv.mkDerivation {
   name = "sw_vers";
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     cat >$out/bin/sw_vers <<EOF
     #!${stdenv.shell}
     if test "\$#" -eq 0 ;
-    then 
+    then
       echo "ProductName:    Mac OS X"
       echo "ProductVersion: 10.7.5"
       echo "BuildVersion:   11G63"


### PR DESCRIPTION
I found that `binutils_raw` gave me errors when building other packages in Darwin. This simply uses `binutils` instead. I'm not sure whether this fix would affect others, but it works well in my local test.